### PR TITLE
Creating support for 'any' type . . . 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Each level is described by the following properties in a python dictionary:
 | ---- | ---- | ---- | ---- | ---- |
 | display_name | Name to be used in the display | True | False | n/a |
 | description | Helpful information about this element | False | False | Blank string |
-| type | Data type of the value. Should be one of map, list, string, number or boolean | False | True | n/a |
+| type | Data type of the value. Should be one of map, list, string, number, boolean or any(4) | False | True | n/a |
 | value_schema | Schema to be used for any of the child values by default. | Depends(1) | True | n/a |
 | verbatim | Any information to be saved along with schema. (3) | False | False | None |
 | allow_none | Allow None value.  No validations are made if the value is None | False | False | False |
@@ -61,7 +61,7 @@ Each level is described by the following properties in a python dictionary:
 1. For each complex type of object, schema is required either directly or through inheritance.  Schema defined here is used for all children where an explicit schema is not defined.
 2. Data is only validated and never modified.  Validation errors are listed as a simple list of strings.
 3. Verbatim data is for other consumers for example UI to drive the widgets or to give hints.  It has no meaning for the backend.
-
+4. Any type has no validations done except for any custom validations.  Use with care.  You are creating the schema to avoid any in the first place :-)
 
 
 Lambda Support

--- a/pyschema.py
+++ b/pyschema.py
@@ -168,6 +168,8 @@ class SchemaNode(object):
             schema_node = ListNode(level, schema_dict)
         elif node_type == 'boolean':
             schema_node = BooleanNode(level, schema_dict)
+        elif node_type == 'any':
+            schema_node = AnyNode(level, schema_dict)
         else:
             raise SchemaError('Unknown type at level %s' % level)
 
@@ -175,9 +177,15 @@ class SchemaNode(object):
         if len(schema_dict) > 0:
             raise SchemaError('Invalid entries (%s) in schema at level %s for type %s' %
                                                 (','.join(schema_dict.keys()), level, node_type))
-
         # Return the schema node
         return schema_node
+
+
+class AnyNode(SchemaNode):
+    expected_types = (str, unicode, list, dict, set, tuple, int)
+
+    def validate_data(self, data):
+        return [ ]
 
 
 class StringNode(SchemaNode):

--- a/samples/any_map.py
+++ b/samples/any_map.py
@@ -1,0 +1,25 @@
+from pyschema import Schema
+
+s = Schema({
+    'known_children': {
+        'a': {
+            'type': 'number',
+            'display_name': 'A NUM'
+        },
+        'b': {
+            'type': 'string',
+            'display_name': 'B STRING'
+        }
+    },
+    'display_name': 'ANY MAP',
+    'value_schema': {
+        'type': 'any',
+        'display_name': 'ANY VALUE'
+    },
+    'allow_unknown_children': True
+})
+
+print "Invalid B " + "\n".join(s.validate({'a': 10, 'b': 10}))
+print "Valid" + "\n".join(s.validate({'a': 10, 'b': 'string'}))
+print "Valid Any " + "\n".join(s.validate({'a': 10, 'z': 10}))
+print "Valid Any " + "\n".join(s.validate({'x': 10, 'z': 10}))


### PR DESCRIPTION
Use it as sparingly as possible and perhaps have some custom validation.  
